### PR TITLE
Fix release script and CircleCI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,9 @@ jobs:
           keys:
             - v1-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
       - run:
+          name: Set crate version from tag
+          command: SKIP_COMMIT=true ./release.sh
+      - run:
           name: Verify crate can be packaged
           command: cargo package --allow-dirty
       - run:

--- a/release.sh
+++ b/release.sh
@@ -3,54 +3,69 @@
 # Release script for nvo_servers
 # Usage: ./release.sh [patch|minor|major]
 
-set -e
+set -euo pipefail
 
-# Default to patch version
-VERSION_TYPE=${1:-patch}
+# If a tag is present on HEAD (or provided via RELEASE_TAG/CIRCLE_TAG), use it directly
+# `git tag --points-at HEAD` works for both lightweight and annotated tags
+HEAD_TAG="${RELEASE_TAG:-${CIRCLE_TAG:-$(git tag --points-at HEAD | head -n 1)}}"
 
-# Get current version from Cargo.toml
-CURRENT_VERSION=$(grep "^version" Cargo.toml | sed 's/version = "\(.*\)"/\1/')
-echo "Current version: $CURRENT_VERSION"
+if [[ -n "$HEAD_TAG" ]]; then
+    # Trim the leading 'v' if present
+    NEW_VERSION="${HEAD_TAG#v}"
+    echo "Using tag version: $NEW_VERSION"
+else
+    # Default to patch version when no tag is provided
+    VERSION_TYPE=${1:-patch}
 
-# Calculate new version
-IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
-MAJOR=${VERSION_PARTS[0]}
-MINOR=${VERSION_PARTS[1]}
-PATCH=${VERSION_PARTS[2]}
+    # Get current version from Cargo.toml (first occurrence only)
+    CURRENT_VERSION=$(grep -m1 "^version" Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+    echo "Current version: $CURRENT_VERSION"
 
-case $VERSION_TYPE in
-    major)
-        MAJOR=$((MAJOR + 1))
-        MINOR=0
-        PATCH=0
-        ;;
-    minor)
-        MINOR=$((MINOR + 1))
-        PATCH=0
-        ;;
-    patch)
-        PATCH=$((PATCH + 1))
-        ;;
-    *)
-        echo "Invalid version type. Use: patch, minor, or major"
-        exit 1
-        ;;
-esac
+    # Calculate new version
+    IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+    MAJOR=${VERSION_PARTS[0]}
+    MINOR=${VERSION_PARTS[1]}
+    PATCH=${VERSION_PARTS[2]}
 
-NEW_VERSION="$MAJOR.$MINOR.$PATCH"
-echo "New version: $NEW_VERSION"
+    case $VERSION_TYPE in
+        major)
+            MAJOR=$((MAJOR + 1))
+            MINOR=0
+            PATCH=0
+            ;;
+        minor)
+            MINOR=$((MINOR + 1))
+            PATCH=0
+            ;;
+        patch)
+            PATCH=$((PATCH + 1))
+            ;;
+        *)
+            echo "Invalid version type. Use: patch, minor, or major"
+            exit 1
+            ;;
+    esac
 
-# Update Cargo.toml
-sed -i "s/^version = \".*\"/version = \"$NEW_VERSION\"/" Cargo.toml
+    NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+    echo "New version: $NEW_VERSION"
+fi
 
-# Run tests
+# Update Cargo.toml (only the first version entry)
+sed -i "0,/^version = \".*\"/s//version = \"$NEW_VERSION\"/" Cargo.toml
+
 echo "Running tests..."
 cargo test
 
-# Commit and tag
-git add Cargo.toml
-git commit -m "Release v$NEW_VERSION"
-git tag -a "v$NEW_VERSION" -m "Release version $NEW_VERSION"
+# Commit and tag unless skipped or the tag already exists (useful for CI)
+if [[ "${SKIP_COMMIT:-}" != "true" ]]; then
+    if git rev-parse -q --verify "v$NEW_VERSION" >/dev/null; then
+        echo "Tag v$NEW_VERSION already exists. Skipping commit and tag."
+    else
+        git add Cargo.toml
+        git commit -m "Release v$NEW_VERSION"
+        git tag -a "v$NEW_VERSION" -m "Release version $NEW_VERSION"
+    fi
+fi
 
 echo "Release prepared! To publish, run:"
-echo "  git push origin main --tags" 
+echo "  git push origin main --tags"


### PR DESCRIPTION
## Summary
- honor `CIRCLE_TAG` or `RELEASE_TAG` by checking tags on `HEAD`
- skip committing/tagging during CI
- run release script in CircleCI publish job so crate version matches the tag

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68517b75aba483238f1f2e3902df5c5b